### PR TITLE
feat(joueurs-stats): ajout des méthodes, routes et repositories pour …

### DIFF
--- a/src/app/Joueurs/JoueursStats/JoueursStatsController.ts
+++ b/src/app/Joueurs/JoueursStats/JoueursStatsController.ts
@@ -75,10 +75,21 @@ export class JoueursStatsController extends Controller {
             this.handleError(res, error)
         }
     }
+
     // GET /joueurs/stats-serveur/total-stats/
     async getTotalStats(req: Request, res: Response): Promise<void> {
         try {
             const stat = await this.model.getTotalStats()
+            this.sendSuccess(res, stat)
+        } catch (error) {
+            this.handleError(res, error)
+        }
+    }
+
+    // GET /joueurs/stats-serveur/total-stats-only-modded-server/
+    async getTotalStatsOnlyModdedServer(req: Request, res: Response): Promise<void> {
+        try {
+            const stat = await this.model.getTotalStatsOnlyModdedServer()
             this.sendSuccess(res, stat)
         } catch (error) {
             this.handleError(res, error)

--- a/src/app/Joueurs/JoueursStats/JoueursStatsModel.ts
+++ b/src/app/Joueurs/JoueursStats/JoueursStatsModel.ts
@@ -110,9 +110,14 @@ export class JoueursStatsModel extends Model implements JoueursStatsInterface {
         return await this.repository.getStatsByServer(serveur_id);
     }
 
-    // Méthode pour obtenir le total des statistiques d'un joueur par son UID par serveur
+    // Méthode pour obtenir le total des statistiques d'un joueur
     async getTotalStats(){
         return await this.repository.getTotalStats();
+    }
+
+    // Méthode pour obtenir le total des statisitques des joueurs sur l'ensemble des serveurs moddée
+    async getTotalStatsOnlyModdedServer(){
+        return await this.repository.getTotalStatsOnlyModdedServer();
     }
 
     // Méthode pour obtenir le total des statistiques d'un joueur par son UID par serveur

--- a/src/app/Joueurs/JoueursStats/JoueursStatsRepository.ts
+++ b/src/app/Joueurs/JoueursStats/JoueursStatsRepository.ts
@@ -124,6 +124,34 @@ export class JoueursStatsRepository extends Repository<JoueursStatsInterface> {
         );
     }
 
+    // Méthode pour obtenir le total des statistiques de l'ensemble des joueurs sur les serveurs moddée
+    async getTotalStatsOnlyModdedServer(): Promise<JoueursStatsInterface[]> {
+        return await super.query(
+            `
+                SELECT
+                    js.compte_id,
+                    MAX(j.playername) AS playername,
+                    SUM(js.tmps_jeux) AS tmps_jeux,
+                    SUM(js.nb_mort) AS nb_mort,
+                    SUM(js.nb_kills) AS nb_kills,
+                    SUM(js.nb_playerkill) AS nb_playerkill,
+                    SUM(js.nb_blocs_detr) AS nb_blocs_detr,
+                    SUM(js.nb_blocs_pose) AS nb_blocs_pose,
+                    SUM(js.dist_total) AS dist_total,
+                    SUM(js.dist_pieds) AS dist_pieds,
+                    SUM(js.dist_elytres) AS dist_elytres,
+                    SUM(js.dist_vol) AS dist_vol,
+                    MAX(js.dern_enregistrment) AS dern_enregistrment
+                    FROM ${this.tableName} js
+                    JOIN joueurs j ON js.compte_id = j.compte_id
+                    JOIN serveurs s ON js.serveur_id = s.id
+                    WHERE s.modpack != 'Minecraft Vanilla'
+                    GROUP BY js.compte_id
+                
+            `
+        )
+    }
+
     // Méthode pour obtenir le total des statistiques d'un joueur par son UID
     async getTotalStatsByUid(uid: string): Promise<JoueursStatsInterface[]> {
         return await super.query(

--- a/src/app/Joueurs/JoueursStats/JoueursStatsRoutes.ts
+++ b/src/app/Joueurs/JoueursStats/JoueursStatsRoutes.ts
@@ -92,6 +92,15 @@ export class JoueursStatsRoutes extends Routes{
             comment: "GET /api/joueurs/stats-serveur/total-stats/",
             description: "Obtenir le total des statistiques de l'ensemble des joueurs"
         },
+        {
+            id: 58,
+            alias: "otr-joueurs-totalStats-only-modded-server-getByUid",
+            route: "/joueurs/stats-serveur/total-stats-only-modded-server",
+            method: "GET",
+            parameters: "",
+            comment: "GET /api/joueurs/stats-serveur/total-stats-only-modded-server/",
+            description: "Obtenir le total des statistiques de l'ensemble des joueurs sur les serveurs moddées"
+        }
 
     ]
 
@@ -124,6 +133,11 @@ export class JoueursStatsRoutes extends Routes{
 
         this.router.get("/total-stats/", Routes.safeHandler(
             (req, res) => this.controller.getTotalStats(req, res),
+            "Erreur lors de la récupération des statistiques totales par UID."
+        ));
+
+        this.router.get("/total-stats-only-modded-server/", Routes.safeHandler(
+            (req, res) => this.controller.getTotalStatsOnlyModdedServer(req, res),
             "Erreur lors de la récupération des statistiques totales par UID."
         ));
 


### PR DESCRIPTION
…récupérer les statistiques des joueurs sur serveurs moddées

Ajout de nouvelles fonctionnalités pour :
- `/joueurs/stats-serveur/total-stats-only-modded-server/` afin d'obtenir les statistiques totales des joueurs uniquement sur les serveurs moddées.
- Méthodes correspondantes dans le modèle, le repository, le contrôleur et les routes.